### PR TITLE
Don't add keyboard-open to CSS if keyboard is already hidden

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -133,6 +133,11 @@ var wasOrientationChange = false;
 var KEYBOARD_OPEN_CSS = 'keyboard-open';
 
 /**
+ * Timer that adds KEYBOARD_OPEN_CSS class to the body.
+ */
+var keyboardOpenCssTimer;
+
+/**
  * CSS class that indicates a scroll container.
  */
 var SCROLL_CONTAINER_CSS = 'scroll-content';
@@ -550,6 +555,7 @@ function keyboardWaitForResize(callback, isOpening) {
  */
 function keyboardHide() {
   clearTimeout(keyboardFocusOutTimer);
+  clearTimeout(keyboardOpenCssTimer);
   //console.log("keyboardHide");
 
   ionic.keyboard.isOpen = false;
@@ -621,7 +627,7 @@ function keyboardShow() {
     ionic.trigger('scrollChildIntoView', details, true);
   }
 
-  setTimeout(function(){
+  keyboardOpenCssTimer = setTimeout(function() {
     document.body.classList.add(KEYBOARD_OPEN_CSS);
   }, 400);
 


### PR DESCRIPTION
#### Short description of what this resolves:

Don't add keyboard-open to CSS if keyboard is already hidden

The 'keyboard-open' CSS class is added to body after a 400ms delay, but
nothing stops somebody from hiding the keyboard during this short period
of time, for example by tapping on empty space.

#### Changes proposed in this pull request:

- Kill the timer responsible for adding this class when the keyboard hides.

**Ionic Version**: 1.x

See this comment for some more details:

https://github.com/driftyco/ionic/issues/3041#issuecomment-276296886