### PR TITLE
fix(history): fixes Back Button issue (#122). Issue occurs when switc…

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -282,7 +282,7 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
           var viewIds = Object.keys(viewHistory.views);
           viewIds.forEach(function(viewId) {
             var view = viewHistory.views[viewId];
-            if ( view.backViewId === switchToView.viewId ) {
+            if ((view.backViewId === switchToView.viewId) && (view.historyId !== switchToView.historyId)) {
               view.backViewId = null;
             }
           });

--- a/test/unit/angular/service/history.unit.js
+++ b/test/unit/angular/service/history.unit.js
@@ -1547,4 +1547,57 @@ describe('Ionic History', function() {
 
   }));
 
+  it('should not remove backView references from Views in the same history stack', inject(function($state, $ionicHistory) {
+
+    var tab1Container = {};
+    var tab2Container = {};
+    ionicHistory.registerHistory(tab1Container);
+    ionicHistory.registerHistory(tab2Container);
+
+    // register tab1, view1
+    $state.go('tabs.tab1view1');
+    rootScope.$apply();
+    var tab1view1Reg = ionicHistory.register(tab1Container, false);
+
+    // register tab2, view1
+    $state.go('tabs.tab2view1');
+    rootScope.$apply();
+    var tab2view1Reg = ionicHistory.register(tab2Container, false);
+
+    // register tab2, view2
+    $state.go('tabs.tab2view2');
+    rootScope.$apply();
+    var tab2view2Reg = ionicHistory.register(tab2Container, false);
+    var tab2view2 = ionicHistory.getViewById(tab2view2Reg.viewId);
+    expect(tab2view2.backViewId).toEqual(tab2view1Reg.viewId);
+
+    // go back to tab2, view1
+    $state.go('tabs.tab2view1');
+    rootScope.$apply();
+    tab2view1Reg = ionicHistory.register(tab2Container, false);
+
+    // register tab1, view1
+    $state.go('tabs.tab1view1');
+    rootScope.$apply();
+    tab1view1Reg = ionicHistory.register(tab1Container, false);
+
+    // go to tab1, view 2
+    // register tab1, view2
+    $state.go('tabs.tab1view2');
+    rootScope.$apply();
+    var tab1view2Reg = ionicHistory.register(tab1Container, false);
+    currentView = ionicHistory.currentView();
+    expect(currentView.backViewId).toEqual(tab1view1Reg.viewId);
+
+    // register tab2, view1
+    $state.go('tabs.tab2view1');
+    rootScope.$apply();
+    tab2view1Reg = ionicHistory.register(tab2Container, false);
+    currentView = ionicHistory.currentView();
+    expect(currentView.backViewId).toEqual(tab1view2Reg.viewId);
+    expect(tab2view2.historyId).toEqual(currentView.historyId);
+    expect(tab2view2.backViewId).toEqual(currentView.viewId);
+
+  }));
+
 });


### PR DESCRIPTION
…hing tabs and navigating to children views.

#### Short description of what this resolves:

This fixes a Back Button issue (#122) which occurs when a View's `backViewId` reference is removed during a View transition (usually happens on Tab switch). This is a result of setting `backViewId` to `null` whenever there is a circular cycle (which creates an infinite loop), i.e.: T1V1 -> T2V1 -> T2V2 -> T1V1. The iteration through Views, however, does not take into account Views in the same History stack. This could potentially remove `backViewId` from Views within the same History stack causing the Back Button to disappear when navigating to a child View.

#### Changes proposed in this pull request:

- Only set `backViewId` to `null` for Views not in the same History stack

**Ionic Version**: 1.3.2
**Fixes**: #122 
