### PR TITLE
Updated doc template api.template

### DIFF
--- a/config/docs/templates/api/api.template.html
+++ b/config/docs/templates/api/api.template.html
@@ -7,11 +7,11 @@ docType: "<$ doc.docType $>"
 ---
 
 <div class="improve-docs">
-<a href='http://github.com/driftyco/ionic/tree/1.x/<$ doc.relativePath $>#L<$ doc.startingLine $>'>
+<a href='http://github.com/driftyco/ionic-v1/tree/master/<$ doc.relativePath $>#L<$ doc.startingLine $>'>
 View Source
 </a>
 &nbsp;
-<a href='http://github.com/driftyco/ionic/edit/1.x/<$ doc.relativePath $>#L<$ doc.startingLine $>'>
+<a href='http://github.com/driftyco/ionic-v1/edit/master/<$ doc.relativePath $>#L<$ doc.startingLine $>'>
 Improve this doc
 </a>
 </div>


### PR DESCRIPTION
#### Short description of what this resolves:

Use the new paths with the directory changes from Github (ionic 1.X moving to ionic-v1)

#### Changes proposed in this pull request:

- Changed the URL in the links to refer to the right ones

**Ionic Version**: 1
**Fixes**: #
