### PR TITLE
Fix nav bar title computed width

### DIFF
--- a/js/angular/controller/headerBarController.js
+++ b/js/angular/controller/headerBarController.js
@@ -110,7 +110,8 @@ function($scope, $element, $attrs, $q, $ionicConfig, $ionicHistory) {
       // to calculate the width of the title
       var children = angular.element(element).children();
       for ( var i = 0; i < children.length; i++ ) {
-        if ( angular.element(children[i]).hasClass('nav-bar-title') ) {
+        var child = angular.element(children[i]);
+        if ( child.hasClass('nav-bar-title') && !child.hasClass('hide') ) {
           element = children[i];
           break;
         }

--- a/js/angular/directive/refresher.js
+++ b/js/angular/directive/refresher.js
@@ -101,7 +101,7 @@ IonicModule
 
         $scope.$on('scroll.refreshComplete', function() {
           $scope.$evalAsync(function() {
-            if(scrollCtrl.scrollView){
+            if (scrollCtrl.scrollView) {
               scrollCtrl.scrollView.finishPullToRefresh();
             }
           });


### PR DESCRIPTION
#### Short description of what this resolves:

Fix the computed nav bar title width.

#### Changes proposed in this pull request:

Previously for the width, the first element with the `nav-bar-title` class was used, but it can be the one hidden (cached) from the previous screen, used for animations, so the change was to check that we do not use the hidden one.

By the way, I also fixed spacing issue in `refresher.js` to allow starting the validation. The 17 broken unit tests were already broken before my fix (on OSX).

**Ionic Version**: 1.x 

**Fixes**: #38 , https://github.com/driftyco/ionic/issues/4661
