### PR TITLE
Allow ion-nav-bar to work in modals

### DIFF
--- a/js/angular/controller/navBarController.js
+++ b/js/angular/controller/navBarController.js
@@ -35,6 +35,11 @@ function($scope, $element, $attrs, $compile, $timeout, $ionicNavBarDelegate, $io
     $element.addClass('nav-bar-container');
     ionic.DomUtil.cachedAttr($element, 'nav-bar-transition', $ionicConfig.views.transition());
 
+    // check if the navbar is within a modal view
+    var ele = $element[0];
+    while((ele = ele.parentNode) && !/ion-modal-view/i.test(ele.tagName));
+    self.inModal = !!ele;
+
     // create two nav bar blocks which will trade out which one is shown
     self.createHeaderBar(false);
     self.createHeaderBar(true);
@@ -372,7 +377,10 @@ function($scope, $element, $attrs, $compile, $timeout, $ionicNavBarDelegate, $io
 
     // set non primary to hide second
     for (var x = 0; x < $ionicNavBarDelegate._instances.length; x++) {
-      if ($ionicNavBarDelegate._instances[x] !== self) $ionicNavBarDelegate._instances[x].visibleBar(false);
+      var instance = $ionicNavBarDelegate._instances[x];
+      if (instance !== self && self.inModal === instance.inModal) {
+        instance.visibleBar(false);
+      }
     }
   };
 

--- a/js/angular/controller/viewController.js
+++ b/js/angular/controller/viewController.js
@@ -24,11 +24,10 @@ function($scope, $element, $attrs, $compile, $rootScope) {
   self.init = function() {
     deregIonNavBarInit();
 
-    var modalCtrl = $element.inheritedData('$ionModalController');
     navViewCtrl = $element.inheritedData('$ionNavViewController');
 
-    // don't bother if inside a modal or there's no parent navView
-    if (!navViewCtrl || modalCtrl) return;
+    // don't bother if there's no parent navView
+    if (!navViewCtrl) return;
 
     // add listeners for when this view changes
     $scope.$on('$ionicView.beforeEnter', self.beforeEnter);


### PR DESCRIPTION
#### Short description of what this resolves:

This allows using `<ion-nav-bar>` directive properly inside modal, with animations and back button working as expected.

#### Changes proposed in this pull request:

- Detects whether the `<ion-nav-bar>` is within a modal or not and separate those within and those not when updating.
- Allows `<ion-view>` lifecycle events to be triggered when inside a modal that has a `<ion-nav-view`

You can now use nested states inside modals, with routes like this one:
```js
    .state('navInsideModal', {
      // the route can have an url or not, both are working
      views: {
        'modal-nav@': {
          templateUrl: 'nav-inside-modal.html',
          controller: 'navInsideModalController as vm'
        }
      }
    })
```
Then you can use in a modal this way:
```js
var modal = $ionicModal.fromTemplate(`
          <ion-modal-view> 
            <ion-nav-bar>
              <ion-nav-back-button></ion-nav-back-button>
            </ion-nav-bar>
            <ion-nav-view name="modal-nav"></ion-nav-view>
          </ion-modal-view>
        `, {
        scope: $rootScope,
        hardwareBackButtonClose: false // disable to allow back button navigation
      });
modal.show();
// disable animation for the first view to show up in modal
$ionicHistory.nextViewOptions({ disableAnimate: true });
$state.go('navInsideModal');

// now you can navigate in modal using regular $state.go() calls with
// states using the `modal-nav@` nested view. 
```

**Ionic Version**: 1.x 

**Fixes**: #1838, #1893, [trello issue](https://trello.com/c/5YqqFf8y/88-nested-states-in-modals), [related forum post](https://forum.ionicframework.com/t/ion-nav-bar-invisible-inside-modal/6996)