### PR TITLE
Fix on slide.js example

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -15,7 +15,7 @@
  * @usage
  * ```html
  * <ion-content scroll="false">
- *   <ion-slides  options="options" slider="data.slider">
+ *   <ion-slides  options="options" slider="slider">
  *     <ion-slide-page>
  *       <div class="box blue"><h1>BLUE</h1></div>
  *     </ion-slide-page>


### PR DESCRIPTION
Weird thing, in the HTML example "data.slider" is used as a slider attribute (line 18), but this value is never initialized or used elsewhere, I think the $scope.slider initialized line 84 is the one that should be used.

#### Short description of what this resolves:

The example is more clear now, even through ion-slides is working without a defined 'slider' attribute for some reason

#### Changes proposed in this pull request:

- Changed the slider attribute in the html example from data.slider to slider.

**Ionic Version**: 1.x