### PR TITLE
Update on max slide length

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -127,8 +127,8 @@ function($animate, $timeout, $compile) {
 
           var slidesLength = _this.__slider.slides.length;
 
-          // Don't allow pager to show with > 10 slides
-          if (slidesLength > 10) {
+          // Don't allow pager to show with > options.maxSlideLength or 10 slides if none is specified
+          if (slidesLength > (_this._options.maxSlideLength || 10)) {
             $scope.showPager = false;
           }
 


### PR DESCRIPTION
Added a maxSlideLength option to replace the '10' arbitrary static value

#### Short description of what this resolves:

Replaces a static arbitrary length by an user specified one

#### Changes proposed in this pull request:

- Addition of a maxSlideLength option

**Ionic Version**: 1.x