### PR TITLE
add Enter keypress to ionic popups

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -396,6 +396,16 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
     //DEPRECATED: notify the promise with an object with a close method
     popup.responseDeferred.notify({ close: popup.responseDeferred.close });
 
+    // if any keypress handlers were requested, go ahead and assign them now
+    // options.keyPressHandlers is the user-generated assoc:   keycode => function()
+    // popup.keyPressHandlers is a list of event-listener handles returned by addEventListener()
+    // and is used to unbind these event listeners when the popup is closing ("then" block below)
+    popup.element[0].keyPressHandlers = options.keyPressHandlers || {};
+    popup.keylistener = popup.element[0].addEventListener('keypress', function (keyEvent) {
+      var userfunc = this.keyPressHandlers[keyEvent.keyCode];
+      if (userfunc) userfunc(popup);
+    });
+
     doShow();
 
     return popup.responseDeferred.promise;
@@ -409,6 +419,8 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
         if (index !== -1) {
           popupStack.splice(index, 1);
         }
+
+        popup.element[0].removeEventListener('keypress', popup.keylistener);
 
         popup.remove();
 
@@ -443,7 +455,17 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
   }
 
   function showAlert(opts) {
+    var keyPressHandlers = {
+      "13": function (popup) { // 13 = Enter = OK
+        var button = popup.scope.buttons[0];
+        var tapper = popup.scope.$buttonTapped;
+        var fclick = new MouseEvent('click', { 'view':window, 'bubbles':true, 'cancelable':true });
+        tapper(button,fclick);
+      }
+    };
+
     return showPopup(extend({
+      keyPressHandlers: keyPressHandlers,
       buttons: [{
         text: opts.okText || 'OK',
         type: opts.okType || 'button-positive',
@@ -455,7 +477,17 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
   }
 
   function showConfirm(opts) {
+      var keyPressHandlers = {
+      "13": function (popup) { // 13 = Enter = OK
+        var button = popup.scope.buttons[1];
+        var tapper = popup.scope.$buttonTapped;
+        var fclick = new MouseEvent('click', { 'view':window, 'bubbles':true, 'cancelable':true });
+        tapper(button,fclick);
+      }
+    };
+
     return showPopup(extend({
+      keyPressHandlers: keyPressHandlers,
       buttons: [{
         text: opts.cancelText || 'Cancel',
         type: opts.cancelType || 'button-default',
@@ -480,7 +512,18 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
       text = '<span>' + opts.template + '</span>';
       delete opts.template;
     }
+
+    var keyPressHandlers = {
+      "13": function (popup) { // 13 = Enter = OK
+        var button = popup.scope.buttons[1];
+        var tapper = popup.scope.$buttonTapped;
+        var fclick = new MouseEvent('click', { 'view':window, 'bubbles':true, 'cancelable':true });
+        tapper(button,fclick);
+      }
+    };
+
     return showPopup(extend({
+      keyPressHandlers: keyPressHandlers,
       template: text + '<input ng-model="data.response" '
         + 'type="{{ data.fieldtype }}"'
         + 'maxlength="{{ data.maxlength }}"'


### PR DESCRIPTION
#### Short description of what this resolves:

$ionicPopup.prompt does not support the Enter and Escape key. I found this PR https://github.com/driftyco/ionic/pull/4739. I test it and the enter button works as expected. So I think could be useful. 

#### Changes proposed in this pull request:

Enter is triggered by the Go/Enter button on the software keyboard, and expected behavior would be to click the OK button for you.

**Ionic Version**: 1.x

**Fixes**: #
